### PR TITLE
Updated composer.json to have the same PHPUnit versions as cakephp 3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ return [
 ];
 ```
 
-In yout controller use the InvokeActionTrait
+In your controller use the InvokeActionTrait
 
 ```php
 
@@ -209,6 +209,9 @@ class MyControllerController extends AppController
     }
 }
 ```
+
+## Adding The CakePHP Request and Session Objects to The Container
+To get the Session and Request objects added to the container just set the key 'useRequest' with the value boolean true in the configuration. 
 
 ## What is Pimple?
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "cakephp/cakephp": "~3.0",
-        "phpunit/phpunit": "*"
+        "phpunit/phpunit": "^5.7.14|^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -32,3 +32,7 @@ foreach ( $scopes as $name => $config ) {
 if (!empty($config['actionInjections'])) {
     \Cake\Event\EventManager::instance()->on(new \RochaMarcelo\CakePimpleDi\Event\ActionInjectionListener($config['actionInjections']));
 }
+
+if (isset($config['useRequest']) && $config['useRequest']) {
+    \Cake\Event\EventManager::instance()->on(new \RochaMarcelo\CakePimpleDi\Event\ContainerDispatchListener());
+}

--- a/src/Event/ContainerDispatchListener.php
+++ b/src/Event/ContainerDispatchListener.php
@@ -1,0 +1,38 @@
+<?php
+namespace RochaMarcelo\CakePimpleDi\Event;
+
+use Cake\Event\Event;
+use Cake\Event\EventListenerInterface;
+use Cake\Http\ServerRequest;
+use RochaMarcelo\CakePimpleDi\Di\DiTrait;
+
+/**
+ * Class ContainerDispatchListener
+ * @package RochaMarcelo\CakePimpleDi\Event
+ */
+class ContainerDispatchListener implements EventListenerInterface
+{
+    use DiTrait;
+
+    /**
+     * @return array
+     */
+    public function implementedEvents()
+    {
+        return [
+            'Dispatcher.beforeDispatch' => 'containerizeRequest',
+        ];
+    }
+
+    /**
+     * @param Event $event Event object
+     * @param ServerRequest $request ServerRequest object
+     * @return void
+     */
+    public function containerizeRequest(Event $event, ServerRequest $request)
+    {
+        $di = $this->di();
+        $di->set('request', $request);
+        $di->set('session', $request->getSession());
+    }
+}

--- a/tests/TestCase/Event/ContainerDispatchListenerTest.php
+++ b/tests/TestCase/Event/ContainerDispatchListenerTest.php
@@ -1,0 +1,43 @@
+<?php
+namespace RochaMarcelo\CakePimpleDi\Test\TestCase\Event;
+
+use Cake\Http\ActionDispatcher;
+use Cake\Http\Response;
+use Cake\Http\ServerRequest;
+use Cake\Network\Session;
+use Cake\TestSuite\TestCase;
+use RochaMarcelo\CakePimpleDi\Di\DiTrait;
+use RochaMarcelo\CakePimpleDi\Event\ContainerDispatchListener;
+
+/**
+ * Class ContainerDispatchListenerTest
+ * @package RochaMarcelo\CakePimpleDi\Test\TestCase\Event
+ */
+class ContainerDispatchListenerTest extends TestCase
+{
+    use DiTrait;
+
+    /**
+     * Test that the ContainerDispatchEventListener add the request and session objects to the container.
+     * @return void
+     */
+    public function testBeforeDispatchAddsRequestAndSession()
+    {
+        $response = new Response();
+        $dispatcher = new ActionDispatcher();
+
+        $req = new ServerRequest();
+        $res = new Response();
+
+        $dispatcher->getEventManager()->on(new ContainerDispatchListener());
+        $dispatcher->getEventManager()->on('Dispatcher.beforeDispatch', function () use ($response) {
+            return $response;
+        });
+        $dispatcher->dispatch($req, $res);
+
+        $session = $this->di()->get('session');
+        $request = $this->di()->get('request');
+        $this->assertInstanceOf(Session::class, $session);
+        $this->assertInstanceOf(ServerRequest::class, $request);
+    }
+}


### PR DESCRIPTION
Here is the pull request we discussed for adding session/request objects into the container. I've update the README.md with instructions on how to use the feature. I've also add unit tests for putting session and request in the container. 

I updated the composer json file with versions for phpunit that match cakephp's phpunit. Otherwise my unit test would not have worked. There appears to have already been one broken test in the unit test directory.

Looking forward to your feedback.